### PR TITLE
Avoid usage of globbing

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -133,7 +133,7 @@ clean:
 	make -C tests clean
 
 depend: $(AUTOGEN)
-	$(OCAMLDEP) -native $(OCAMLINC) *.ml *.mli > depend
+	$(OCAMLDEP) -native $(OCAMLINC) $(MLSRC) $(MLISRC) > depend
 
 include depend
 


### PR DESCRIPTION
Clobbers under windows need to be resolved by the called program. This is the only remaining problem in a native windows environment, the failsafe link from the patch #1552 seems to work without problem.