### PR TITLE
Z.pow/Z.root: Avoid overflow with large exponents

### DIFF
--- a/caml_z.c
+++ b/caml_z.c
@@ -2713,7 +2713,7 @@ CAMLprim value ml_z_pow(value base, value exp)
   CAMLparam2(base,exp);
   CAMLlocal1(r);
   mpz_t mbase;
-  int e = Long_val(exp);
+  intnat e = Long_val(exp);
   if (e < 0) 
     caml_invalid_argument("Z.pow: exponent must be non-negative");
   ml_z_mpz_init_set_z(mbase, base);
@@ -2728,7 +2728,7 @@ CAMLprim value ml_z_root(value a, value b)
   CAMLparam2(a,b);
   CAMLlocal1(r);
   mpz_t ma;
-  int mb = Long_val(b);
+  intnat mb = Long_val(b);
   if (mb < 0) 
     caml_invalid_argument("Z.root: exponent must be non-negative");
   ml_z_mpz_init_set_z(ma, a);


### PR DESCRIPTION
This fix prevents errors such as the following:

```
Z.pow (Z.of_int 1) 766490601062400;;
Exception: Invalid_argument "Z.pow: exponent must be non-negative".
```