### PR TITLE
Only install dllzarith optional.

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -97,7 +97,7 @@ endif
 
 ifeq ($(INSTMETH),findlib)
 install:
-	$(OCAMLFIND) install -destdir "$(INSTALLDIR)" zarith META $(TOINSTALL) dllzarith.$(DLLSUFFIX)
+	$(OCAMLFIND) install -destdir "$(INSTALLDIR)" zarith META $(TOINSTALL) -optional dllzarith.$(DLLSUFFIX)
 
 uninstall:
 	$(OCAMLFIND) remove -destdir "$(INSTALLDIR)" zarith


### PR DESCRIPTION
The normal install methods tests if dllzarith is available before
installing it, but the findlib install method always install the
dllzarith.