### PR TITLE
Only mark stack non-executable when ELF defined.

### DIFF
--- a/caml_z_x86_64.S
+++ b/caml_z_x86_64.S
@@ -20,8 +20,10 @@
  */
 
         
+#if defined(Z_ELF)
         /* makes the stack non-executable. */
         .section .note.GNU-stack,"",@progbits
+#endif
 
         
         /* helper functions */


### PR DESCRIPTION
Compiling Zarith now fails on Mac OS 10.12.6 using clang and OCaml 4.05.0. `clang --version` gives me
```
 Apple LLVM version 8.0.0 (clang-800.0.38), Target: x86_64-apple-darwin16.7.0
```

Error message is
```
caml_z_x86_64.S:24:27: error: unexpected token in '.section' directive
#         .section .note.GNU-stack,"",@progbit
```
I think commit https://github.com/ocaml/Zarith/commit/96a8242def2023cf2d24cb29ec0a80437d5d4019 was only tested on Linux but it does not work on Mac OS (clang 8).
