### PR TITLE
fix build on Raspberry Debian Jessie

### DIFF
--- a/caml_z_arm.S
+++ b/caml_z_arm.S
@@ -22,7 +22,7 @@
 
         
         /* makes the stack non-executable. */
-        .section .note.GNU-stack,"",@progbits
+        .section .note.GNU-stack,"",%progbits
 
 
         /* helper functions */


### PR DESCRIPTION
see https://github.com/ocaml/Zarith/issues/14 as reference.

Replacing the @ with % in the .section .note.GNU-stack,"",@progbits in order to be able to install Zarith again on Raspberry Debian Jessie.

Tested it on Raspberry Pi Debian Jessie (2017-09-07).