### PR TITLE
Add infix comparison operators to Q and Z

### DIFF
--- a/q.ml
+++ b/q.ml
@@ -361,3 +361,9 @@ let (~$) = of_int
 let (//) = of_ints
 let (~$$) = of_bigint
 let (///) = make
+let (=) = equal
+let (<) = lt
+let (>) = gt
+let (<=) = leq
+let (>=) = geq
+let (<>) a b = not (equal a b)

--- a/q.mli
+++ b/q.mli
@@ -272,3 +272,21 @@ val (~$$): Z.t -> t
 
 val (///): Z.t -> Z.t -> t
 (** Creates a rational from two [Z.t]. *)
+
+val (=): t -> t -> bool
+(** Same as [equal]. *)
+
+val (<): t -> t -> bool
+(** Same as [lt]. *)
+
+val (>): t -> t -> bool
+(** Same as [gt]. *)
+
+val (<=): t -> t -> bool
+(** Same as [leq]. *)
+
+val (>=): t -> t -> bool
+(** Same as [geq]. *)
+
+val (<>): t -> t -> bool
+(** [a <> b] is equivalent to [not (equal a b)]. *)

--- a/z.mlip
+++ b/z.mlip
@@ -609,6 +609,25 @@ external (~$): int -> t = "ml_z_of_int" @NOALLOC
 external ( ** ): t -> int -> t = "ml_z_pow"
 (** Power [pow]. *)
 
+val (=): t -> t -> bool
+(** Same as [equal]. *)
+
+val (<): t -> t -> bool
+(** Same as [lt]. *)
+
+val (>): t -> t -> bool
+(** Same as [gt]. *)
+
+val (<=): t -> t -> bool
+(** Same as [leq]. *)
+
+val (>=): t -> t -> bool
+(** Same as [geq]. *)
+
+val (<>): t -> t -> bool
+(** [a <> b] is equivalent to [not (equal a b)]. *)
+
+
 (** {1 Miscellaneous} *)
 
 val version: string

--- a/z.mlp
+++ b/z.mlp
@@ -215,5 +215,11 @@ external (lsl): t -> int -> t = shift_left@ASM
 external (asr): t -> int -> t = shift_right@ASM
 external (~$): int -> t = "ml_z_of_int" @NOALLOC
 external ( ** ): t -> int -> t = "ml_z_pow"
+let (=) = equal
+let (<) = lt
+let (>) = gt
+let (<=) = leq
+let (>=) = geq
+let (<>) a b = not (equal a b)
 
 let version = @VERSION


### PR DESCRIPTION
This patch adds infix comparison operators to Q and Z, which come handy in situations like this:
```
Q.((x < x1 && x < x2) || (x > x1 && x > x2) ||
   (y < y1 && y < y2) || (y > y1 && y > y2))
```

[Num](https://github.com/ocaml/num) offers a different syntax:
```
val ( =/ ) : num -> num -> bool
val ( </ ) : num -> num -> bool
val ( >/ ) : num -> num -> bool
val ( <=/ ) : num -> num -> bool
val ( >=/ ) : num -> num -> bool
val ( <>/ ) : num -> num -> bool
```

However, my experience shows that it's way too easy to mistakenly use the generic comparison operators with `num` (or `Q.t`), which results in unexpected (and very annoying) behaviour. So, I propose to shadow the generic operators, although it feels like bad taste.