### PR TITLE
Remove non-executable stack directive.

### DIFF
--- a/caml_z_x86_64_mingw64.S
+++ b/caml_z_x86_64_mingw64.S
@@ -20,10 +20,6 @@
  */
 
         
-        /* makes the stack non-executable. */
-        .section .note.GNU-stack,"",@progbits
-
-        
         /* helper functions */
         /* **************** */
 


### PR DESCRIPTION
Mingw has a coff target for which the assembler directive for
marking the stack as non-executable is not supported.