### PR TITLE
Also detect mingw64 as a target

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -18,7 +18,7 @@ EXE          := .exe
 else
 OBJSUFFIX    := o
 LIBSUFFIX    := a
-ifeq "$(shell $(OCAMLC) -config |grep system)" "system: mingw"
+ifeq "$(findstring mingw,$(shell $(OCAMLC) -config |grep system))" "mingw"
 DLLSUFFIX    := dll
 EXE          := .exe
 else


### PR DESCRIPTION
This patch makes ZArith's build process also detect the mingw64 target (and not only mingw).