### PR TITLE
Make test-suite work on Windows

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,11 +12,11 @@ endif
 
 test:: zq.exe
 	@echo "Testing zq (native)..."
-	@if ./zq.exe | cmp -s zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
+	@if ./zq.exe | diff -w zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
 
 test:: zq.byt
 	@echo "Testing zq (bytecode)..."
-	@if ./zq.byt | cmp -s zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
+	@if ./zq.byt | diff -w zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
 
 ifeq ($(HAS_NUM),true)
 test:: bi.exe
@@ -26,7 +26,7 @@ endif
 
 test:: pi.exe
 	@echo "Testing pi..."
-	@if ./pi.exe 500 | cmp -s pi.output - ; then echo "pi: passed"; else echo "pi: FAILED"; exit 2; fi
+	@if ./pi.exe 500 | diff -w pi.output - ; then echo "pi: passed"; else echo "pi: FAILED"; exit 2; fi
 
 test:: tofloat.exe
 	@echo "Testing tofloat..."

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ test:: zq.exe
 
 test:: zq.byt
 	@echo "Testing zq (bytecode)..."
-	@if ocamlrun -I .. ./zq.byt | cmp -s zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
+	@if ./zq.byt | cmp -s zq.output$(WORDSIZE) - ; then echo "zq: passed"; else echo "zq: FAILED"; exit 2; fi
 
 ifeq ($(HAS_NUM),true)
 test:: bi.exe


### PR DESCRIPTION
* This patch replaces the use of "cmp" by "diff -w" in the code that detects deviations in test results from a reference source file. The reason is that white-space differences occur on native Windows ports of OCaml.
 
* Moreover, it calls the bytecode executable directly, without going via ocamlrun. This is due to the   observation, that zq.byt aborts on both Windows ports of OCaml due to an unknown C primitive from ZArith's C-stubs:  
```
ocamlc -I .. -ccopt "-L.." zarith.cma nums.cma -o zq.byt zq.ml
Testing zq (bytecode)...
Fatal error: unknown C primitive `ml_z_numbits'
zq: FAILED
```
This error does not occur and all tests succeed if the bytecode executable is called directly.