### PR TITLE
Absolute path in configure

### DIFF
--- a/configure
+++ b/configure
@@ -128,7 +128,7 @@ searchbin()
     done
     unset IFS
     # Finally, test absolute path
-    if test -x $1; then echo "found"; return 1; fi
+    if test "/${1#'/'}" = "$1" ; then if test -x $1; then echo "found"; return 1; fi ; fi
     echo "not found"
     return 0
 }

--- a/configure
+++ b/configure
@@ -128,7 +128,7 @@ searchbin()
     done
     unset IFS
     # Finally, test absolute path
-    if test "/${1#'/'}" = "$1" ; then if test -x $1; then echo "found"; return 1; fi ; fi
+    if test "/${1#/}" = "$1" ; then if test -x $1; then echo "found"; return 1; fi ; fi
     echo "not found"
     return 0
 }

--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ searchbin()
     if test "x$1" = "x"; then return 0; fi
     echo_n "binary $1: "
     # Test absolute path
-    if test -x $1; then echo "found in $i"; return 1; fi
+    if test -x $1; then echo "found"; return 1; fi
     # Search in $PATH
     IFS=':'
     for i in $PATH

--- a/configure
+++ b/configure
@@ -119,8 +119,6 @@ searchbin()
 {
     if test "x$1" = "x"; then return 0; fi
     echo_n "binary $1: "
-    # Test absolute path
-    if test -x $1; then echo "found"; return 1; fi
     # Search in $PATH
     IFS=':'
     for i in $PATH
@@ -128,8 +126,10 @@ searchbin()
         if test -z "$i"; then i='.'; fi
         if test -x $i/$1; then echo "found in $i"; unset IFS; return 1; fi
     done
-    echo "not found"
     unset IFS
+    # Finally, test absolute path
+    if test -x $1; then echo "found"; return 1; fi
+    echo "not found"
     return 0
 }
 

--- a/configure
+++ b/configure
@@ -119,6 +119,9 @@ searchbin()
 {
     if test "x$1" = "x"; then return 0; fi
     echo_n "binary $1: "
+    # Test absolute path
+    if test -x $1; then echo "found in $i"; return 1; fi
+    # Search in $PATH
     IFS=':'
     for i in $PATH
     do


### PR DESCRIPTION
On the cluster I use, by default we have a very old version of gcc. To use a newer version of gcc, we need to load a module. In that case, the `CC` variable is defined as `/opt/pb/gcc-4.9.2/bin/gcc` which is an absolute path, and zarith can't compile.


When the binary is not found in any of the `$PATH`, I added a test to see if it is defined as an absolute path (starts with a '/'), and to see if it is executable.