### PR TITLE
update the ocaml configuration script with the perl one

### DIFF
--- a/z_pp.ml
+++ b/z_pp.ml
@@ -1,9 +1,12 @@
 let archname = ref ""
+let noalloc = ref true
+let version = ref "VERSION"
 let usage = "Usage: './z_pp architecture"
 
 let () =
   Arg.parse 
-    [] (* no options *)
+    ["-noalloc", Arg.Set noalloc, "noalloc attribute available";
+     "-ov", Arg.Set_string version, "ocaml compiler version"]
     (fun name -> archname := name)
     usage;
   if !archname = "" 
@@ -11,6 +14,8 @@ let () =
       print_endline usage; 
       exit 1
     end
+
+let noalloc_str = if !noalloc then "[@@noalloc]" else "\"noalloc\""
 
 let asmfilename = "caml_z_" ^ !archname ^ ".S"
 
@@ -51,6 +56,8 @@ let treat_file =
     try
       while true do
 	let line_in = input_line input in
+        let line_in = Str.(global_replace (regexp "@VERSION") (Printf.sprintf "%S" !version) line_in) in
+        let line_in = Str.(global_replace (regexp "@NOALLOC") noalloc_str line_in) in
 	let line_out = 
 	  if Str.string_match rASM line_in 0
 	  then


### PR DESCRIPTION
we have a fork of Zarith in MirageOS that builds with dune, in order to do cross-compilation and embedded builds more easily. As part of [that port](https://github.com/ocaml/Zarith/compare/master...dune-universe:duniverse-master), we use the ocaml script to configure the repository instead of the perl one (to remove the need for perl to be installed).

this PR syncs the functionality of the perl script `z_pp.pl` with the ocaml version, so that the configurations from both are identical.  The arg interface to the ocaml script changes slightly to account for the OCaml compiler version options. This script doesnt seem to be currently used, but I figured it would be useful to send this upstream anyway in case there's interest.