### PR TITLE
Move infix comparison operators in submodule

### DIFF
--- a/z.mlip
+++ b/z.mlip
@@ -614,24 +614,27 @@ external (~$): int -> t = "ml_z_of_int" @NOALLOC
 external ( ** ): t -> int -> t = "ml_z_pow"
 (** Power [pow]. *)
 
-val (=): t -> t -> bool
-(** Same as [equal]. *)
+module Compare : sig
 
-val (<): t -> t -> bool
-(** Same as [lt]. *)
+    val (=): t -> t -> bool
+    (** Same as [equal]. *)
 
-val (>): t -> t -> bool
-(** Same as [gt]. *)
+    val (<): t -> t -> bool
+    (** Same as [lt]. *)
 
-val (<=): t -> t -> bool
-(** Same as [leq]. *)
+    val (>): t -> t -> bool
+    (** Same as [gt]. *)
 
-val (>=): t -> t -> bool
-(** Same as [geq]. *)
+    val (<=): t -> t -> bool
+    (** Same as [leq]. *)
 
-val (<>): t -> t -> bool
-(** [a <> b] is equivalent to [not (equal a b)]. *)
+    val (>=): t -> t -> bool
+    (** Same as [geq]. *)
 
+    val (<>): t -> t -> bool
+    (** [a <> b] is equivalent to [not (equal a b)]. *)
+
+end
 
 (** {1 Miscellaneous} *)
 

--- a/z.mlp
+++ b/z.mlp
@@ -215,11 +215,14 @@ external (lsl): t -> int -> t = shift_left@ASM
 external (asr): t -> int -> t = shift_right@ASM
 external (~$): int -> t = "ml_z_of_int" @NOALLOC
 external ( ** ): t -> int -> t = "ml_z_pow"
-let (=) = equal
-let (<) = lt
-let (>) = gt
-let (<=) = leq
-let (>=) = geq
-let (<>) a b = not (equal a b)
+
+module Compare = struct
+  let (=) = equal
+  let (<) = lt
+  let (>) = gt
+  let (<=) = leq
+  let (>=) = geq
+  let (<>) a b = not (equal a b)
+end
 
 let version = @VERSION


### PR DESCRIPTION
Since it can become quite annoying if the generic comparison operators are shadowed. As said in  https://github.com/ocaml/Zarith/pull/20#issuecomment-485806969 I tried to update some code using Zarith and ended up having to change a lot of code in order to get it compiling again.

I think it is more save to hide these infix operators in a submodule, which still allows the shorter usage but avoids problems when the module ````Z```` or ````Q```` are opened or included.