### PR TITLE
issue #36: change Q comparison for nan

### DIFF
--- a/q.ml
+++ b/q.ml
@@ -151,9 +151,9 @@ let compare x y =
   | MINF,_ | _,INF -> -1
   | INF,_ | _,MINF -> 1
   | _ ->
-    if x.den == y.den (* implies equality,
-                         especially if immediate value and not a pointer,
-                         in particular in the case den = 1 *)
+    if x.den = y.den (* implies equality,
+                        especially if immediate value and not a pointer,
+                        in particular in the case den = 1 *)
     then Z.compare x.num y.num
     else
       Z.compare
@@ -163,10 +163,35 @@ let compare x y =
 let min a b = if compare a b <= 0 then a else b
 let max a b = if compare a b >= 0 then a else b
 
-let leq a b = compare a b <= 0
-let geq a b = compare a b >= 0
-let lt a b = compare a b < 0
-let gt a b = compare a b > 0
+
+let leq x y =
+  match classify x, classify y with
+  | UNDEF,_ | _,UNDEF -> false
+  | MINF,_ | _,INF -> true
+  | INF,_ | _,MINF -> false
+  | _ ->
+     if x.den = y.den
+     then Z.leq x.num y.num
+     else
+       Z.leq
+         (Z.mul x.num y.den)
+         (Z.mul y.num x.den)
+
+let lt x y =
+  match classify x, classify y with
+  | UNDEF,_ | _,UNDEF -> false
+  | INF,_ | _,MINF -> false
+  | MINF,_ | _,INF -> true
+  | _ ->
+     if x.den = y.den
+     then Z.lt x.num y.num
+     else
+       Z.lt
+         (Z.mul x.num y.den)
+         (Z.mul y.num x.den)
+
+let geq x y = leq y x
+let gt x y = lt y x
 
 let to_string n =
   match classify n with

--- a/q.mli
+++ b/q.mli
@@ -126,7 +126,7 @@ val compare: t -> t -> int
 
 val equal: t -> t -> bool
 (** Equality testing.
-    This is consistent with [compare]; in particular, [undef]=[undef].
+    Unlike [compare], this follows IEEE semantics: [undef] <> [undef].
  *)
 
 val min: t -> t -> t
@@ -136,10 +136,10 @@ val max: t -> t -> t
 (** Returns the largest of its arguments. *)
 
 val leq: t -> t -> bool
-(** Less than or equal. *)
+(** Less than or equal. [leq undef undef] resturns false. *)
 
 val geq: t -> t -> bool
-(** Greater than or equal. *)
+(** Greater than or equal. [leq undef undef] resturns false. *)
 
 val lt: t -> t -> bool
 (** Less than (not equal). *)

--- a/tests/zq.ml
+++ b/tests/zq.ml
@@ -780,7 +780,13 @@ let test_Q () =
           assert (Q.equal (Q.mul x y) (Q.mul y x));
           assert (Q.equal (Q.div x y) (Q.mul x (Q.inv y)));
         ) t_list
-    ) t_list
+    ) t_list;
+  assert (Q.compare Q.undef Q.undef = 0);
+  assert (not (Q.equal Q.undef Q.undef));
+  assert (not (Q.lt  Q.undef Q.undef));
+  assert (not (Q.leq Q.undef Q.undef));
+  assert (not (Q.gt  Q.undef Q.undef));
+  assert (not (Q.geq Q.undef Q.undef))
 
 
 (* main *)


### PR DESCRIPTION
issue #36: change the result of Q.equal, leq, lt, geq, gt for nan argments (to be IEEE compliant)
Q.compare is not changed (following OCaml's compare)
