### PR TITLE
Fix Q.of_string

### DIFF
--- a/q.ml
+++ b/q.ml
@@ -360,7 +360,7 @@ let int_of_base = function
 (* The current implementation supports plain decimals, decimal points,
    scientific notation ('e' or 'E' for base 10 litteral and 'p' or 'P'
    for base 16), and fraction of integers (eg. 1/2). In particular it
-   accepts any numeric litteral -without underscores ('_')- accepted
+   accepts any numeric literal -without underscores ('_')- accepted
    by OCaml's lexer.
    Restrictions:
    - does not handle '_' as their removal should probably be common to

--- a/q.ml
+++ b/q.ml
@@ -424,7 +424,16 @@ let of_string =
       | None -> Z.of_substring_base base s ~pos:i ~len:(j - i), 0
       | Some k ->
         let frac_len = j - k - 1 in
-        let shift = frac_len * shift_right_factor in
+        (* We should only consider actual digits to perform the shift. This will remain
+           correct if we ever accept underscores in the middle of the string *)
+        let num_digits = ref 0 in
+        for h = k + 1 to j - 1 do
+          match s.[h] with
+          | '0' .. '9' | 'A' .. 'F' | 'a' .. 'f' ->
+            incr num_digits
+          | _ -> ()
+        done;
+        let shift = !num_digits * shift_right_factor in
         let without_dot = String.sub s i (k-i) ^ (String.sub s (k+1) frac_len) in
         Z.of_string_base base without_dot, shift
     in

--- a/q.ml
+++ b/q.ml
@@ -362,7 +362,7 @@ let  div_2exp x n =
 let of_string =
   (* return a boolean (true for negative) and the next offset to read *)
   let parse_sign s i =
-    if String.length s <= i
+    if String.length s < i + 1
     then false, i
     else
       match s.[i] with
@@ -412,9 +412,10 @@ let of_string =
     (* shift left due to the exponent *)
     let shift_left, j =
       match find_in_string s ~pos:i ~last:j exponent_pred with
-      | None -> 0, String.length s
+      | None -> 0, j
       | Some ei ->
-        let ez = Z.of_substring_base 10 s ~pos:(ei+1) ~len:(String.length s - ei - 1) in
+        let pos = ei + 1 in
+        let ez = Z.of_substring_base 10 s ~pos ~len:(j - pos) in
         Z.to_int ez, ei
     in
     (* shift right due to the radix *)

--- a/q.ml
+++ b/q.ml
@@ -357,6 +357,15 @@ let int_of_base = function
   | B10 -> 10
   | B16 -> 16
 
+(* [find_in_string s ~pos ~last pred] find the first index in the string between [pos]
+   (inclusive) and [last] (exclusive) that satisfy the predicate [pred] *)
+let rec find_in_string s ~pos ~last p =
+  if pos = last
+  then None
+  else if p s.[pos]
+    then Some pos
+    else find_in_string s ~pos:(pos + 1) ~last p
+
 (* The current implementation supports plain decimals, decimal points,
    scientific notation ('e' or 'E' for base 10 litteral and 'p' or 'P'
    for base 16), and fraction of integers (eg. 1/2). In particular it
@@ -388,18 +397,6 @@ let of_string =
       | '0',('o'|'O') -> B8, i + 2
       | '0',('b'|'B') -> B2, i + 2
       | _ -> B10, i
-  in
-  (* [find_in_string s ~pos ~last pred] find the first index in the string between [pos]
-     (inclusive) and [last] (exclusive) that satisfy the predicate [pred] *)
-  let find_in_string s ~pos ~last p =
-    let rec loop s ~pos:i ~last p =
-      if i = last
-      then None
-      else if p s.[i]
-      then Some i
-      else loop s ~pos:(i + 1) ~last p
-    in
-    loop s ~pos ~last p
   in
   let find_exponent_mark = function
     | B10 -> (function 'e' | 'E' -> true | _ -> false)

--- a/tests/ofstring.ml
+++ b/tests/ofstring.ml
@@ -151,6 +151,18 @@ let test_of_string_Q () =
       Printf.printf "%s failed. Expected %s. Got %s\n" d (Q.to_string y)
                     (Printexc.to_string exc)
   in
+  let z_and_float_agree s =
+    let a = float_of_string s |> Q.of_float in
+    let b = Q.of_string s in
+    if Q.equal a b
+    then ()
+    else
+      Printf.printf
+        "Q.of_string (%s) returned %s, expected %s\n"
+        s
+        (Q.to_string b)
+        (Q.to_string a)
+  in
 
   round_trip_Q ();
 
@@ -163,7 +175,15 @@ let test_of_string_Q () =
   succ "Q.of_string" Q.of_string "+" Q.zero;
   succ "Q.of_string" Q.of_string "-" Q.zero;
   succ "Q.of_string" Q.of_string "0x" Q.zero;
+  succ "Q.of_string" Q.of_string "0X" Q.zero;
+  succ "Q.of_string" Q.of_string "0o" Q.zero;
+  succ "Q.of_string" Q.of_string "0O" Q.zero;
   succ "Q.of_string" Q.of_string "0b" Q.zero;
+  succ "Q.of_string" Q.of_string "0B" Q.zero;
+  succ "Q.of_string" Q.of_string "0b101" (Q.of_string "5");
+  succ "Q.of_string" Q.of_string "0B101" (Q.of_string "5");
+  succ "Q.of_string" Q.of_string "0o101" (Q.of_string "65");
+  succ "Q.of_string" Q.of_string "0O101" (Q.of_string "65");
 
   fail "Q.of_string" Q.of_string "0b2";
   fail "Q.of_string" Q.of_string "0o8";
@@ -185,10 +205,15 @@ let test_of_string_Q () =
   succ "Q.of_string" Q.of_string "+0xff.8" (Q.of_float 255.5);
   succ "Q.of_string" Q.of_string "-0xFF.8" (Q.of_float (-255.5));
   succ "Q.of_string" Q.of_string "-0xff.8" (Q.of_float (-255.5));
-  succ "Q.of_string" Q.of_string "-0.1e1" (Q.minus_one);
-  succ "Q.of_string" Q.of_string "-0.1E1" (Q.minus_one);
-  succ "Q.of_string" Q.of_string "-0x0.1P1" (Q.minus_one);
-  succ "Q.of_string" Q.of_string "-0x0.1p1" (Q.minus_one);
-  succ "Q.of_string" Q.of_string "6.674e-11" (Q.of_string "0.00000000006674")
+  succ "Q.of_string" Q.of_string "-0.1e1" (float_of_string "-0.1e1" |> Q.of_float) ;
+  succ "Q.of_string" Q.of_string "-0.1E1" (float_of_string "-0.1E1" |> Q.of_float) ;
+  succ "Q.of_string" Q.of_string "-0x0.1P1" (float_of_string "-0x0.1P1" |> Q.of_float) ;
+  succ "Q.of_string" Q.of_string "-0x0.1p1" (float_of_string "-0x0.1p1" |> Q.of_float) ;
+  succ "Q.of_string" Q.of_string "6.674e-11" (Q.of_string "0.00000000006674") ;
+
+  z_and_float_agree "-0x0.1p1" ;
+  z_and_float_agree "-0x0.1P1" ;
+  z_and_float_agree "-0x0.1p10" ;
+  z_and_float_agree "-0x0.1p10"
 
 let _ = test_of_string_Q ()

--- a/tests/ofstring.ml
+++ b/tests/ofstring.ml
@@ -152,7 +152,7 @@ let test_of_string_Q () =
                     (Printexc.to_string exc)
   in
   let z_and_float_agree s =
-    let a = float_of_string s |> Q.of_float in
+    let a = Q.of_float (float_of_string s) in
     let b = Q.of_string s in
     if Q.equal a b
     then ()
@@ -205,10 +205,10 @@ let test_of_string_Q () =
   succ "Q.of_string" Q.of_string "+0xff.8" (Q.of_float 255.5);
   succ "Q.of_string" Q.of_string "-0xFF.8" (Q.of_float (-255.5));
   succ "Q.of_string" Q.of_string "-0xff.8" (Q.of_float (-255.5));
-  succ "Q.of_string" Q.of_string "-0.1e1" (float_of_string "-0.1e1" |> Q.of_float) ;
-  succ "Q.of_string" Q.of_string "-0.1E1" (float_of_string "-0.1E1" |> Q.of_float) ;
-  succ "Q.of_string" Q.of_string "-0x0.1P1" (float_of_string "-0x0.1P1" |> Q.of_float) ;
-  succ "Q.of_string" Q.of_string "-0x0.1p1" (float_of_string "-0x0.1p1" |> Q.of_float) ;
+  succ "Q.of_string" Q.of_string "-0.1e1" (Q.of_float (float_of_string "-0.1e1")) ;
+  succ "Q.of_string" Q.of_string "-0.1E1" (Q.of_float (float_of_string "-0.1E1")) ;
+  succ "Q.of_string" Q.of_string "-0x0.1P1" (Q.of_float (float_of_string "-0x0.1P1")) ;
+  succ "Q.of_string" Q.of_string "-0x0.1p1" (Q.of_float (float_of_string "-0x0.1p1")) ;
   succ "Q.of_string" Q.of_string "6.674e-11" (Q.of_string "0.00000000006674") ;
 
   z_and_float_agree "-0x0.1p1" ;


### PR DESCRIPTION
- exponent are parsed in decimal base
- the base prefix is case insensitive (allowing 0x and 0X)
- fix parsing of hexadecimal with radix
- reduce the number of string allocation