### PR TITLE
multiple fixes for of_string functions

### DIFF
--- a/caml_z.c
+++ b/caml_z.c
@@ -603,6 +603,12 @@ CAMLprim value ml_z_of_substring_base(value b, value v, value offset, value leng
       if (*d == 'o' || *d == 'O') { base = 8; d++; }
       else if (*d == 'x' || *d == 'X') { base = 16; d++; }
       else if (*d == 'b' || *d == 'B') { base = 2; d++; }
+      else {
+        /* The leading zero is not part of a base prefix. This is an
+           important distinction for the check below looking at
+           leading underscore
+         */
+        d--; }
     }
   }
   if (base < 2 || base > 16)

--- a/q.ml
+++ b/q.ml
@@ -421,11 +421,8 @@ let rec find_in_string s ~pos ~last p =
 (* The current implementation supports plain decimals, decimal points,
    scientific notation ('e' or 'E' for base 10 litteral and 'p' or 'P'
    for base 16), and fraction of integers (eg. 1/2). In particular it
-   accepts any numeric literal -without underscores ('_')- accepted
-   by OCaml's lexer.
+   accepts any numeric literal accepted by OCaml's lexer.
    Restrictions:
-   - does not handle '_' as their removal should probably be common to
-     Z.of_string and Q.of_string
    - exponents in scientific notation should fit on an integer
    - scientific notation only available in hexa and decimal (as in OCaml) *)
 let of_string =
@@ -489,8 +486,7 @@ let of_string =
             | B2 | B8 -> assert false
           in
           let frac_len = j - k - 1 in
-          (* We should only consider actual digits to perform the shift. This will remain
-             correct if we ever accept underscores in the middle of the string *)
+          (* We should only consider actual digits to perform the shift. *)
           let num_digits = ref 0 in
           for h = k + 1 to j - 1 do
             match s.[h] with

--- a/q.ml
+++ b/q.ml
@@ -412,7 +412,7 @@ let int_of_base = function
 (* [find_in_string s ~pos ~last pred] find the first index in the string between [pos]
    (inclusive) and [last] (exclusive) that satisfy the predicate [pred] *)
 let rec find_in_string s ~pos ~last p =
-  if pos = last
+  if pos >= last
   then None
   else if p s.[pos]
     then Some pos

--- a/tests/ofstring.ml
+++ b/tests/ofstring.ml
@@ -188,7 +188,7 @@ let test_of_string_Q () =
     match f,q with
     | None, None -> ()
     | Some f, Some q ->
-      if not (Q.equal (Q.of_float f) q)
+      if not ((Q.to_float q) = f)
       then
         Printf.printf
         "Q.of_string (%s) returned %s, expected %s\n"
@@ -271,6 +271,20 @@ let test_of_string_Q () =
   q_and_float_agree "12.34e03_";
 
   q_and_float_agree "000_001";
-  q_and_float_agree "001_000"
+  q_and_float_agree "001_000";
+
+  (* underscores right after dot are accepted. *)
+  q_and_float_agree "1._001";
+  q_and_float_agree "._001";
+  (* float_of_string doesn't accept strings without digits, Q and Z do (e.g. "+", "-", "0x", "." *)
+  (* q_and_float_agree "."; *)
+  (* q_and_float_agree "._"; *)
+
+
+  q_and_float_agree "0.x00a";
+  q_and_float_agree ".-001";
+
+  ()
+
 
 let _ = test_of_string_Q ()

--- a/tests/ofstring.ml
+++ b/tests/ofstring.ml
@@ -113,6 +113,8 @@ let test_of_string_Z () =
   z_and_int_agree "1_23";
   z_and_int_agree "12_3";
   z_and_int_agree "123_";
+  z_and_int_agree "0x_123";
+  z_and_int_agree "0_123";
 
   let s = Z.format "%#b" p120 in
   let n = String.length s in

--- a/tests/ofstring.ml
+++ b/tests/ofstring.ml
@@ -273,6 +273,8 @@ let test_of_string_Q () =
   q_and_float_agree "000_001";
   q_and_float_agree "001_000";
 
+  q_and_float_agree "123.";
+
   (* underscores right after dot are accepted. *)
   q_and_float_agree "1._001";
   q_and_float_agree "._001";


### PR DESCRIPTION

- `Z.of_string` should accept string with a `0_` prefix.
- `Q.of_string` should not accept a sign after a dot (aka `Q.of_string ".-0"` should fail)
- `Q.of_string` should accept leading underscore after a dot, even if the integer part is empty (aka `Q.of_string "._123"` should succeed)