### PR TITLE
Optimize the fast paths for comparison and equality tests

### DIFF
--- a/caml_z.c
+++ b/caml_z.c
@@ -3145,11 +3145,22 @@ int ml_z_custom_compare(value arg1, value arg2)
   int r;
   Z_CHECK(arg1); Z_CHECK(arg2);
 #if Z_FAST_PATH
-  if (Is_long(arg1) && Is_long(arg2)) {
-    /* fast path */
-    if (arg1 > arg2) return 1;
-    else if (arg1 < arg2) return -1;
-    else return 0;
+  /* Value-equal small integers are equal.
+     Pointer-equal big integers are equal as well. */
+  if (arg1 == arg2) return 0;
+  if (Is_long(arg2)) {
+    if (Is_long(arg1)) {
+      return arg1 > arg2 ? 1 : -1;
+    } else {
+      /* Either arg1 is positive and arg1 > Z_MAX_INT >= arg2 -> result +1
+             or arg1 is negative and arg1 < Z_MIN_INT <= arg2 -> result -1 */
+      return Z_SIGN(arg1) ? -1 : 1;
+    }
+  }
+  else if (Is_long(arg1)) {
+    /* Either arg2 is positive and arg2 > Z_MAX_INT >= arg1 -> result -1
+           or arg2 is negative and arg2 < Z_MIN_INT <= arg1 -> result +1 */
+    return Z_SIGN(arg2) ? 1 : -1;
   }
 #endif
   r = 0;

--- a/tests/bi.ml
+++ b/tests/bi.ml
@@ -137,6 +137,17 @@ let test_pow msg gf tf =
         ) g_t_list
     ) pow_list
 
+let test_comparison msg gf tf l =
+  Printf.printf "testing %s on %i x %i numbers\n%!" msg (List.length l) (List.length l);
+  List.iter
+    (fun (g1,t1) ->
+      List.iter
+        (fun (g2,t2) ->
+            let g' = gf g1 g2 and t' = tf t1 t2 in
+            if g' <> t' then failwith (Printf.sprintf "%s failure: arg1=%s arg2=%s" msg (B.string_of_big_int g1) (B.string_of_big_int g2))
+        ) l
+    ) l
+
 let filt_none _ = true
 let filt_pos x = B.sign_big_int x >= 0
 let filt_nonzero2 (_,d) = B.sign_big_int d <> 0
@@ -178,5 +189,10 @@ let _ = test_shift "shift_right_big_int" B.shift_right_big_int T.shift_right_big
 let _ = test_shift "shift_right_towards_zero_big_int" B.shift_right_towards_zero_big_int T.shift_right_towards_zero_big_int
 
 let _ = test_pow "power_big_int_positive_int" B.power_big_int_positive_int T.power_big_int_positive_int
+
+let _ = test_comparison "compare" B.compare_big_int Z.compare g_t_list
+let _ = test_comparison "equal" B.eq_big_int Z.equal g_t_list
+let _ = test_comparison "lt" B.lt_big_int (fun x y -> x < y) g_t_list
+let _ = test_comparison "ge" B.ge_big_int (fun x y -> x >= y) g_t_list
 
 let _ = Printf.printf "All tests passed!\n"


### PR DESCRIPTION
We take advantage of the fact that numbers of type `Z.t` have unique representations.  Hence, a number that is not represented by a small integer is outside the range `[Z_MIN_INT, Z_MAX_INT]`.  Its sign tells us on which side of the interval it is.
