### PR TITLE
ocamldoc is not required to build Zarith

### DIFF
--- a/configure
+++ b/configure
@@ -198,7 +198,9 @@ searchbinreq $ocaml
 searchbinreq $ocamlc
 searchbinreq $ocamldep
 searchbinreq $ocamlmklib
-searchbin $ocamldoc
+if searchbin $ocamldoc; then
+  ocamldoc=''
+fi
 
 if test -n "$CC"; then
   searchbinreq "$CC"

--- a/configure
+++ b/configure
@@ -198,7 +198,7 @@ searchbinreq $ocaml
 searchbinreq $ocamlc
 searchbinreq $ocamldep
 searchbinreq $ocamlmklib
-searchbinreq $ocamldoc
+searchbin $ocamldoc
 
 if test -n "$CC"; then
   searchbinreq "$CC"

--- a/project.mak
+++ b/project.mak
@@ -86,8 +86,12 @@ zarith_top.cma: zarith_top.cmo
 	$(OCAMLC) $(DEBUG) -o $@ -a $<
 
 doc: $(MLISRC)
+ifneq ($(OCAMLDOC),)
 	mkdir -p html
 	$(OCAMLDOC) -html -d html -charset utf8 $+
+else
+	$(error ocamldoc is required to build the documentation)
+endif
 
 zarith_version.ml: META
 	(echo "let"; grep "version" META | head -1) > zarith_version.ml


### PR DESCRIPTION
`configure` complains if `ocamldoc` isn't found. However, the tool is only needed if you run the optional `make doc` step. This PR both makes the search optional and then adds error handling on the `doc` target if `ocamldoc` was not found.

Spotted in the wild - we build ocaml in CI without ocamldoc to reduce the cache sizes!