### PR TITLE
shell: test -a|o is not POSIX

### DIFF
--- a/configure
+++ b/configure
@@ -116,7 +116,7 @@ searchbin()
     echo_n "binary $1: "
     case "$1" in
       /*|./*|../*)
-        if test -f "$1" -a -x "$1"
+        if test -f "$1" && test -x "$1"
         then echo "found"; return 1
         else echo "not found"; return 0
         fi;;
@@ -125,7 +125,7 @@ searchbin()
     for i in $PATH
     do
         if test -z "$i"; then i='.'; fi
-        if test -f $i/$1 -a -x $i/$1; then echo "found in $i"; unset IFS; return 1; fi
+        if test -f $i/$1 && test -x $i/$1; then echo "found in $i"; unset IFS; return 1; fi
     done
     echo "not found"
     unset IFS
@@ -265,7 +265,7 @@ fi
 # installation method
 
 searchbin ocamlfind
-if test $? -eq 1 -a $ocamlfind != "no"; then 
+if test $? -eq 1 && test $ocamlfind != "no"; then 
     instmeth='findlib'
     if test "$installdir" = "auto"
     then installdir=`ocamlfind printconf destdir`; fi
@@ -296,7 +296,7 @@ fi
 
 # check GMP, MPIR
 
-if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+if test "$gmp" = 'gmp' || test "$gmp" = 'auto'; then
     checkinc gmp.h
     if test $? -eq 1; then
         checklib gmp
@@ -307,7 +307,7 @@ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
         fi
     fi
 fi
-if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then
+if test "$gmp" = 'mpir' || test "$gmp" = 'auto'; then
     checkinc mpir.h
     if test $? -eq 1; then
         checklib mpir


### PR DESCRIPTION
Recent versions of POSIX mark the syntax -a and -o as obsolescent.
See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html
Same as ocaml/ocaml#11005