### PR TITLE
Support MSVC compiler

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+Pending
+- Support MSVC compiler with environment variables for GMP library locations
+  and consistent .exe and .obj extensions. Probe for __gmpn_divexact rather
+  than assume existence [Jonah Beckford]
+
 Release 1.12 (2021-03-03)
 - PR #79: fast path in OCaml (instead of assembly language) [Xavier Leroy]
 - PR #94: remove source preprocessing and simplify configuration [Xavier Leroy]

--- a/caml_z.c
+++ b/caml_z.c
@@ -2702,7 +2702,7 @@ value ml_z_from_mpz(mpz_t op)
   return ml_z_reduce(r, sz, (mpz_sgn(op) >= 0) ? 0 : Z_SIGN_MASK);
 }
 
-#if __GNU_MP_VERSION >= 5
+#if __GNU_MP_VERSION >= 5 && defined(HAS_GMPN_DIVEXACT)
 /* not exported by gmp.h */
 extern void __gmpn_divexact (mp_ptr, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t);
 #endif
@@ -2724,7 +2724,7 @@ CAMLprim value ml_z_divexact(value arg1, value arg2)
   }
 #endif
   Z_MARK_SLOW;
-#if __GNU_MP_VERSION >= 5
+#if __GNU_MP_VERSION >= 5 && defined(HAS_GMPN_DIVEXACT)
   {
     /* mpn_ version */
     Z_ARG(arg1);

--- a/configure
+++ b/configure
@@ -30,12 +30,19 @@ ocamldep='ocamldep'
 ocamldoc='ocamldoc'
 ccinc="$CPPFLAGS"
 cclib="$LDFLAGS"
+cclinkflags="$CCLINKERFLAGS"
 ccdef=''
 mlflags="$OCAMLFLAGS"
 mloptflags="$OCAMLOPTFLAGS"
 mlinc="$OCAMLINC"
 objsuffix="o"
+exeext=""
 ocamlfind="auto"
+linkextrastart=""
+linkexe="-o "
+linkobj="-o "
+linklibstart="-l"
+linklibend=""
 
 # sanitize
 LC_ALL=C
@@ -69,6 +76,16 @@ EOF
     exit
 }
 
+use_msvc() {
+  linkextrastart="-link "
+  linkexe="-Fe"
+  linkobj="-Fo"
+  linklibstart=""
+  linklibend=".lib"
+  objsuffix="obj"
+  exeext=".exe"
+}
+
 # parse arguments
 while : ; do
     case "$1" in
@@ -94,6 +111,8 @@ while : ; do
         -prefixnonocaml|--prefixnonocaml)
             prefixnonocaml="$2"
             shift;;
+        -msvc|--msvc)
+            use_msvc;;
         *)
             echo "unknown option $1, try -help"
             exit 2;;
@@ -144,13 +163,13 @@ searchbinreq()
 checkinc()
 {
     echo_n "include $1: "
-    rm -f tmp.c tmp.o
+    rm -f tmp.c tmp.${objsuffix}
     echo "#include <$1>" > tmp.c
     echo "int main() { return 1; }" >> tmp.c
     r=1
-    $cc $ccopt $ccinc -c tmp.c -o tmp.o >/dev/null 2>/dev/null || r=0
-    if test ! -f tmp.o; then r=0; fi
-    rm -f tmp.c tmp.o
+    $cc $ccopt $ccinc -c tmp.c ${linkobj}tmp.${objsuffix} >/dev/null 2>/dev/null || r=0
+    if test ! -f tmp.${objsuffix}; then r=0; fi
+    rm -f tmp.c tmp.${objsuffix}
     if test $r -eq 0; then echo "not found"; else echo "found"; fi
     return $r
 }
@@ -158,12 +177,26 @@ checkinc()
 checklib()
 {
     echo_n "library $1: "
-    rm -f tmp.c tmp.out
+    rm -f tmp.c tmp${exeext}
     echo "int main() { return 1; }" >> tmp.c
     r=1
-    $cc $ccopt $cclib tmp.c -l$1 -o tmp.out >/dev/null 2>/dev/null || r=0
-    if test ! -x tmp.out; then r=0; fi
-    rm -f tmp.c tmp.o tmp.out
+    $cc $ccopt tmp.c ${linkexe}tmp${exeext} ${linkextrastart}$cclinkflags ${linklibstart}$1${linklibend} >/dev/null 2>/dev/null || r=0
+    if test ! -x tmp${exeext}; then r=0; fi
+    rm -f tmp.c tmp.${objsuffix} tmp${exeext}
+    if test $r -eq 0; then echo "not found"; else echo "found"; fi
+    return $r
+}
+
+checkgmpn_divexact()
+{
+    echo_n "__gmpn_divexact: "
+    rm -f tmp.c tmp${exeext}
+    echo "extern void __gmpn_divexact (mp_ptr, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t);"  >> tmp.c
+    echo "int main() { __gmpn_divexact(0, 0, 0, 0, 0); return 1; }" >> tmp.c
+    r=1
+    $cc $ccopt tmp.c ${linkexe}tmp${exeext} ${linkextrastart}$cclinkflags >/dev/null 2>/dev/null || r=0
+    if test ! -x tmp${exeext}; then r=0; fi
+    rm -f tmp.c tmp.${objsuffix} tmp${exeext}
     if test $r -eq 0; then echo "not found"; else echo "found"; fi
     return $r
 }
@@ -171,12 +204,12 @@ checklib()
 checkcc()
 {
     echo_n "checking compilation with $cc $ccopt: "
-    rm -f tmp.c tmp.out
+    rm -f tmp.c tmp${exeext}
     echo "int main() { return 1; }" >> tmp.c
     r=1
-    $cc $ccopt tmp.c -o tmp.out >/dev/null 2>/dev/null || r=0
-    if test ! -x tmp.out; then r=0; fi
-    rm -f tmp.c tmp.o tmp.out
+    $cc $ccopt tmp.c ${linkexe}tmp${exeext} >/dev/null 2>/dev/null || r=0
+    if test ! -x tmp${exeext}; then r=0; fi
+    rm -f tmp.c tmp.${objsuffix} tmp${exeext}
     if test $r -eq 0; then echo "not working"; else echo "working"; fi
     return $r
 }
@@ -184,9 +217,9 @@ checkcc()
 checkcmxalib()
 {
     echo_n "library $1: "
-    $ocamlopt $mloptflags $1 -o tmp.out >/dev/null 2>/dev/null || r=0
-    if test ! -x tmp.out; then r=0; fi
-    rm -f tmp.out
+    $ocamlopt $mloptflags $1 -o tmp${exeext} >/dev/null 2>/dev/null || r=0
+    if test ! -x tmp${exeext}; then r=0; fi
+    rm -f tmp${exeext}
     if test $r -eq 0; then echo "not found"; else echo "found"; fi
     return $r    
 }
@@ -206,6 +239,10 @@ if test -n "$CC"; then
   searchbinreq "$CC"
   cc="$CC"
   ccopt="$CFLAGS"
+  cc_base=`basename $cc`
+  if test "$cc_base" = cl || test "$cc_base" = cl.exe; then
+    use_msvc
+  fi
 elif ! searchbin 'gcc'; then
   cc='gcc'
   ccopt="-O3 -Wall -Wextra $CFLAGS"
@@ -215,6 +252,9 @@ elif ! searchbin $prefixnonocaml'gcc'; then
 elif ! searchbin 'cc'; then
   cc='cc'
   ccopt="-O3 -Wall -Wextra $CFLAGS"
+elif ! searchbin 'cl'; then
+  cc='cl'
+  use_msvc
 else
   searchbinreq $prefixnonocaml'cc'
   cc=$prefixnonocaml'cc'
@@ -305,6 +345,7 @@ if test "$gmp" = 'gmp' || test "$gmp" = 'auto'; then
         if test $? -eq 1; then 
             gmp='OK'
             cclib="$cclib -lgmp"
+            cclinkflags="$cclinkflags ${linklibstart}gmp${linklibend}"
             ccdef="-DHAS_GMP $ccdef"
         fi
     fi
@@ -316,12 +357,19 @@ if test "$gmp" = 'mpir' || test "$gmp" = 'auto'; then
         if test $? -eq 1; then 
             gmp='OK'
             cclib="$cclib -lmpir"
+            cclinkflags="$cclinkflags ${linklibstart}mpir${linklibend}"
             ccdef="-DHAS_MPIR $ccdef"
         fi
     fi
 fi
 if test "$gmp" != 'OK'; then echo "cannot find GMP nor MPIR"; exit 2; fi
 
+# check for gmpn_divexact in the gmp/mpir library
+
+checkgmpn_divexact
+if test $? -eq 1; then
+    ccdef="-DHAS_GMPN_DIVEXACT $ccdef"
+fi
 
 # OCaml version
 

--- a/zarith.opam
+++ b/zarith.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml/Zarith/issues"
 dev-repo: "git+https://github.com/ocaml/Zarith.git"
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
-  ["./configure"] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ["./configure"] {os != "openbsd" & os != "freebsd" & os != "macos" & !(os = "win32" & os-distribution = "win32")}
   [
     "sh"
     "-exc"
@@ -22,6 +22,28 @@ build: [
     "-exc"
     "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
   ] {os = "macos"}
+  [
+    "sh"
+    "-exc"
+    # Native Windows does not have an analog to /usr/lib or /usr/local/lib. Even
+    # with Cygwin or MSYS2 the user will almost always want a MinGW library at
+    # some unusual path (ex. /mingw64/lib).
+    # An evolving "standard" for OCaml from jonahbeckford@ for consistency across packages is:
+    #   <CLIBRARY>_(LIB|INCLUDE)_DEFAULT[_<uppercased sanitized-with-underscores findlib toolchain>]=<forward-slashed path arguments separated by semicolons>
+    # Ex. GMP_LIB_DEFAULT = -LZ:/build/windows_x86_64/vcpkg_installed/x64-windows/lib;-lgmp
+    # Ex. GMP_INCLUDE_DEFAULT = -IZ:/build/windows_x86_64/vcpkg_installed/x64-windows/include
+    # In Zarith we need the C compiler and linker (MSVC) to see:
+    #   -LIBPATH:Z:/build/windows_x86_64/vcpkg_installed/x64-windows/lib gmp.lib
+    #   -IZ:/build/windows_x86_64/vcpkg_installed/x64-windows/include
+    # while for OCaml (ocamlmklib) Zarith needs to give:
+    #   -LZ:/build/windows_x86_64/vcpkg_installed/x64-windows/lib -lgmp
+    """
+    GMP_MLLIB=$(printf "%s" "${GMP_LIB_DEFAULT:-$GMP_LIB}" | tr ';' ' ')
+    GMP_CCLINKERFLAGS=$(printf "%s" "${GMP_LIB_DEFAULT:-$GMP_LIB}" | sed 's#\\B-L#-LIBPATH:#g; s#\\B-l\\(.*\\)\\b#\\1.lib#g' | tr ';' ' ')
+    GMP_INCLUDE=$(printf "%s" "${GMP_INCLUDE_DEFAULT:-$GMP_INCLUDE}" | tr ';' ' ')
+    LDFLAGS="$LDFLAGS $GMP_MLLIB" CCLINKERFLAGS="$CCLINKERFLAGS $GMP_CCLINKERFLAGS" CPPFLAGS="$CPPFLAGS $GMP_INCLUDE" CFLAGS="$CFLAGS $GMP_INCLUDE" ./configure
+    """
+  ] {os = "win32" & os-distribution = "win32" }
   [make]
 ]
 install: [


### PR DESCRIPTION
#### Changes

1. Since native Windows does not have an analog to `/usr/lib` or
`/usr/local/lib`, use environment variables to pass through
external gmp libraries.

2. `test -x` will fail on Windows "executables" that do not have an .exe
extension, so use .obj and .exe extensions correctly.

3. Standard (vcpkg) MSVC compile of gmp 6.2 does not expose `__gmpn_divexact`
so probe for its existence during ./configure

For item 3 above, before the PR the ca-certs-nss.3.74 package would complain:

```
# ** Cannot resolve symbols for Z:\dckbuild\windows_x86_64\Debug\dksdk\_opam\lib\zarith\libzarith.lib(caml_z.obj):
#  __gmpn_divexact
# File "caml_startup", line 1:
# Error: Error during linking (exit code 2)
```

#### Testing

https://github.com/jonahbeckford/Zarith/runs/5518724099 are the normal GitHub Actions. The probe of `_gmpn_divexact` shows `defines:              -DHAS_GMPN_DIVEXACT -DHAS_GMP` for Ubuntu but not for macOS.

On Win32 with MSVC compiler and MSYS2 shell, the Opam build steps show:

```bash
...
- + GMP_INCLUDE=-IZ:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/include
- + LDFLAGS=' -LZ:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/lib -lgmp'
- + CCLINKERFLAGS=' -LIBPATH:Z:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/lib gmp.lib'
- + CPPFLAGS=' -IZ:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/include'
- + CFLAGS=' -IZ:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/include'
- + ./configure
- binary ocaml: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- binary ocamlc: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- binary ocamldep: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- binary ocamlmklib: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- binary ocamldoc: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- binary gcc: not found
- binary gcc: not found
- binary cc: not found
- binary cl: found in /c/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.26.28801/bin/HostX64/x64
- binary ocamlopt: found in /z/dckbuild/windows_x86_64/Debug/dksdk/ocaml/bin
- checking compilation with cl : working
- include caml/mlvalues.h: found
- library dynlink.cmxa: found
- binary ocamlfind: found in /z/dckbuild/windows_x86_64/Debug/dksdk/_opam/bin
- OCaml's word size is 64
- binary uname: found in /usr/bin
- ./configure: unable to guess system type
-
- This script, last modified 2010-09-24, has failed to recognize
- the operating system you are using. It is advised that you
- download the most up to date version of the config scripts from
-
-   http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
- and
-   http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD
- - If the version you run (./configure) is already up to date, please
- send the following data and any information you think might be
- pertinent to <config-patches@gnu.org> in order to provide the needed
- information to handle your system.
-
- config.guess timestamp = 2010-09-24
-
- uname -m = x86_64
- uname -r = 3.3.4-341.x86_64
- uname -s = MSYS_NT-10.0-22567
- uname -v = 2022-02-15 17:24 UTC
-
- /usr/bin/uname -p = unknown
- /bin/uname -X     =
-
- hostinfo               =
- /bin/universe          =
- /usr/bin/arch -k       =
- /bin/arch              = x86_64
- /usr/bin/oslevel       =
- /usr/convex/getsysinfo =
-
- UNAME_MACHINE = x86_64
- UNAME_RELEASE = 3.3.4-341.x86_64
- UNAME_SYSTEM  = MSYS_NT-10.0-22567
- UNAME_VERSION = 2022-02-15 17:24 UTC
- include gmp.h: found
- library gmp: found
- __gmpn_divexact: not found
- OCaml supports -bin-annot to produce documentation
-
- detected configuration:
-
-   native-code:          yes
-   dynamic linking:      yes
-   defines:              -DHAS_GMP
-   libraries:             -LZ:/dckbuild/windows_x86_64/vcpkg_installed/x64-windows/lib -lgmp -lgmp
-   C options:
-   installation path:    Z:/dckbuild/windows_x86_64/Debug/dksdk/_opam/lib
-   installation method   findlib
-
- configuration successful!
- now type "make" to build
- then type "make install" or "sudo make install" to install
```

Note: The `config.guess` is ancient so it will not recognize MSYS2, but the results of `./config.guess` aren't even used.