### PR TITLE
pass LDFLAGS to ocamlmklib via -ldopt

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -52,7 +52,6 @@ endif
 DEBUG = -g
 OCAMLFLAGS += $(DEBUG) -I +compiler-libs
 OCAMLOPTFLAGS += $(DEBUG) -I +compiler-libs
-LDFLAGS = $(foreach flag, $(LIBS), -ldopt $(flag))
 
 ifeq ($(HASDYNLINK),yes)
 TOBUILD += zarith.cmxs
@@ -72,16 +71,16 @@ tests:
 	make -C tests test
 
 zarith.cma: $(MLSRC:%.ml=%.cmo)
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ -ldopt "$(LIBS)"
 
 zarith.cmxa: $(MLSRC:%.ml=%.cmx)
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ -ldopt "$(LIBS)"
 
 zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
 
 libzarith.$(LIBSUFFIX): $(CSRC:%.c=%.$(OBJSUFFIX))
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ -ldopt "$(LIBS)"
 
 zarith_top.cma: zarith_top.cmo
 	$(OCAMLC) $(DEBUG) -o $@ -a $<

--- a/project.mak
+++ b/project.mak
@@ -52,6 +52,7 @@ endif
 DEBUG = -g
 OCAMLFLAGS += $(DEBUG) -I +compiler-libs
 OCAMLOPTFLAGS += $(DEBUG) -I +compiler-libs
+LDFLAGS = $(foreach flag, $(LIBS), -ldopt $(flag))
 
 ifeq ($(HASDYNLINK),yes)
 TOBUILD += zarith.cmxs
@@ -71,16 +72,16 @@ tests:
 	make -C tests test
 
 zarith.cma: $(MLSRC:%.ml=%.cmo)
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LIBS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
 
 zarith.cmxa: $(MLSRC:%.ml=%.cmx)
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LIBS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
 
 zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
 
 libzarith.$(LIBSUFFIX): $(CSRC:%.c=%.$(OBJSUFFIX))
-	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LIBS)
+	$(OCAMLMKLIB) $(DEBUG) -failsafe -o zarith $+ $(LDFLAGS)
 
 zarith_top.cma: zarith_top.cmo
 	$(OCAMLC) $(DEBUG) -o $@ -a $<


### PR DESCRIPTION
`ocamlmklib` supports some but not all linker flags. we have some `LDFLAGS` that are not supported by `ocamlmklib`, so they need to be passed via `-ldopt`. this PR prepends `-ldopt` to each word in `LIBS` (which is set to `LDFLAGS` in ./configure).