### PR TITLE
Add functions to generate integers pseudo-randomly

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,6 +36,10 @@ test:: ofstring.exe
 	@echo "Testing ofstring..."
 	@./ofstring.exe
 
+test:: chi2.exe
+	@echo "Testing random number generation..."
+	@./chi2.exe
+
 bench:: timings.exe
 	./timings.exe
 

--- a/tests/chi2.ml
+++ b/tests/chi2.ml
@@ -1,0 +1,43 @@
+(* Accumulate [n] samples from function [f] and check the chi-square.
+   Only the low 8 bits of the result of [f] are sampled. *)
+
+let chisquare n f =
+  let r = 256 in
+  let freq = Array.make r 0 in
+  for i = 0 to n - 1 do
+    let t = Z.to_int (Z.logand (f ()) (Z.of_int 0xFF)) in
+    freq.(t) <- freq.(t) + 1
+  done;
+  let expected = float n /. float r in
+  let t =
+    Array.fold_left
+      (fun s x -> let d = float x -. expected in d *. d +. s)
+      0.0 freq in
+  let chi2 = t /. expected in
+  let degfree = float r -. 1.0 in
+  (* The degree of freedom is high, so we approximate as a normal
+     distribution with mean equal to degfree and variance 2 * degfree.
+     Four sigmas correspond to a 99.9968% confidence interval.
+     (Without the approximation, the confidence interval seems to be 99.986%.)
+  *)
+  chi2 <= degfree +. 4.0 *. sqrt (2.0 *. degfree)
+
+let test name f =
+  if not (chisquare 100_000 f)
+  then Printf.printf "%s: suspicious result\n%!" name
+
+let _ =
+  test "random_bits 15 (bits 0-7)"
+       (fun () -> Z.random_bits 15);
+  test "random_bits 32 (bits 12-19)"
+       (fun () -> Z.(shift_right (random_bits 32) 12));
+  test "random_bits 31 (bits 23-30)"
+       (fun () -> Z.(shift_right (random_bits 31) 23));
+  test "random_int 2^30 (bits 0-7)"
+       (fun () -> Z.(random_int (shift_left one 30)));
+  test "random_int 2^30 (bits 21-28)"
+       (fun () -> Z.(shift_right (random_int (shift_left one 30)) 21));
+  test "random_int (256 * p) / p"
+       (let p = Z.of_string "35742549198872617291353508656626642567" in
+        let bound = Z.shift_left p 8 in
+        fun () -> Z.(div (random_int bound) p))

--- a/tests/zq.ml
+++ b/tests/zq.ml
@@ -150,6 +150,17 @@ let chk_testbit x =
   then Printf.printf "(passed)\n"
   else Printf.printf "(FAILED)\n"
 
+let pr_byte =
+  let state = ref 0 in
+  fun () ->
+    state := (!state * 65793 + 4282663) land 0xFF_FF_FF;
+    !state lsr 16
+
+let pr_bytes buf pos len =
+  for i = pos to pos + len - 1 do
+    Bytes.set_uint8 buf i (pr_byte ())
+  done
+
 let test_Z() =
   Printf.printf "0\n = %a\n" pr I.zero;
   Printf.printf "1\n = %a\n" pr I.one;
@@ -746,6 +757,18 @@ let test_Z() =
     I.shift_left (I.of_int 9999) 77;
     I.neg (I.shift_left (I.of_int 123456) 64);
   ];
+
+  Printf.printf "random_bits 45 = %a\n"
+    pr (I.random_bits_gen ~fill:pr_bytes 45);
+  Printf.printf "random_bits 45 = %a\n"
+    pr (I.random_bits_gen ~fill:pr_bytes 45);
+  Printf.printf "random_bits 12 = %a\n"
+    pr (I.random_bits_gen ~fill:pr_bytes 12);
+  Printf.printf "random_int 123456 = %a\n"
+    pr (I.random_int_gen ~fill:pr_bytes (I.of_int 123456));
+  Printf.printf "random_int 9999999 = %a\n"
+    pr (I.random_int_gen ~fill:pr_bytes (I.of_int 9999999));
+
   ()
 
 

--- a/tests/zq.output32
+++ b/tests/zq.output32
@@ -1113,6 +1113,11 @@ numbits / trailing_zeros 1 (passed)
 numbits / trailing_zeros -42 (passed)
 numbits / trailing_zeros 1511006158790834639735881728 (passed)
 numbits / trailing_zeros -2277361236363886404304896 (passed)
+random_bits 45 = 25076743995969
+random_bits 45 = 33510880286625
+random_bits 12 = 1263
+random_int 123456 = 103797
+random_int 9999999 = 1089068
 - 0 = 0
 - 1 = -1
 - -1 = 1

--- a/tests/zq.output64
+++ b/tests/zq.output64
@@ -1113,6 +1113,11 @@ numbits / trailing_zeros 1 (passed)
 numbits / trailing_zeros -42 (passed)
 numbits / trailing_zeros 1511006158790834639735881728 (passed)
 numbits / trailing_zeros -2277361236363886404304896 (passed)
+random_bits 45 = 25076743995969
+random_bits 45 = 33510880286625
+random_bits 12 = 1263
+random_int 123456 = 103797
+random_int 9999999 = 1089068
 - 0 = 0
 - 1 = -1
 - -1 = 1

--- a/z.ml
+++ b/z.ml
@@ -373,11 +373,90 @@ let to_float x =
     end
   end
 
+(* Formatting *)
+
 let print x = print_string (to_string x)
 let output chan x = output_string chan (to_string x)
 let sprint () x = to_string x
 let bprint b x = Buffer.add_string b (to_string x)
 let pp_print f x = Format.pp_print_string f (to_string x)
+
+(* Pseudo-random generation *)
+
+let rec raw_bits_random ?(rng: Random.State.t option) nbits =
+  let rec raw_bits accu n =
+    if n >= nbits then (accu, n) else begin
+      let i =
+        match rng with
+        | None -> Random.bits ()
+        | Some r -> Random.State.bits r in
+      raw_bits (logxor (shift_left accu 30) (of_int i)) (n + 30)
+    end in
+  raw_bits zero 0
+
+let raw_bits_from_bytes ~(fill: bytes -> int -> int -> unit) nbits =
+  let nbytes = (nbits + 7) / 8 in
+  let buf = Bytes.create nbytes in
+  fill buf 0 nbytes;
+  (of_bits (Bytes.to_string buf), nbytes * 8)
+
+let random_bits_aux (f: int -> t * int) nbits =
+  if nbits < 0 then invalid_arg "random_bits: number of bits must be >= 0";
+  let (x, _) = f nbits in
+  extract x 0 nbits
+
+let random_int_aux (f: int -> t * int) bound =
+  if sign bound <= 0 then invalid_arg "random_int: bound must be > 0";
+  let nbits1 = log2up bound in
+  let rec draw () =
+    (* The minimal number of random bits we need to draw is nbits1.
+       However, in the worst case, rejection (as described below)
+       will occur with probability almost 1/2.  So, we draw more bits
+       than strictly necessary to make rejection much less likely.
+       With 4 extra bits, the probability of rejection is less than
+       1/32. *)
+    let (x, nbits) = f (nbits1 + 4) in
+    let y = rem x bound in
+    (* We divide the range of x, namely [0 .. 2^nbits), into
+         - k intervals of width bound :
+             [0 .. bound) [bound.. 2*bound) .. [(k-1) * bound.. k * bound)
+         - the remaining numbers: [k * bound .. 2^nbits)
+
+       k is chosen as large as possible: k = floor (2^nbits / bound).
+
+       If x falls within the k intervals of width bound,
+       y = x mod bound is evenly distributed in [0 .. bound)
+       and we can use it as the pseudo-random number.
+       If x falls within the [k * bound .. 2^nbits) interval,
+       y = x mod bound may not be evenly distributed;
+       we reject and draw again.
+
+       We can decide efficiently whether to reject, as follows.
+       Write 2^nbits = k * bound + r and x = q * bound + y,
+       with r and y in [0 .. bound).
+       If x - y <= 2^nbits - bound, then
+         q * bound = x - y <= 2^nbits - bound < 2^nbits - r = k * bound,
+       hence q < k and we can accept x.
+       Otherwise, 
+         q * bound = x - y > 2^nbits - bound = (k - 1) * bound + r
+       hence q >= k and we must reject x.
+    *)
+    if leq (sub x y) (sub (shift_left one nbits) bound)
+    then y
+    else draw () in
+  draw ()
+
+let random_int ?rng bound =
+  random_int_aux (raw_bits_random ?rng) bound
+let random_bits ?rng nbits =
+  random_bits_aux (raw_bits_random ?rng) nbits
+
+let random_int_gen ~fill bound =
+  random_int_aux (raw_bits_from_bytes ~fill) bound
+let random_bits_gen ~fill nbits =
+  random_bits_aux (raw_bits_from_bytes ~fill) nbits
+
+(* Infix notations *)
 
 let (~-) = neg
 let (~+) x = x

--- a/z.mli
+++ b/z.mli
@@ -649,6 +649,63 @@ external of_bits: string -> t = "ml_z_of_bits"
     trailing zeros in s.
  *)
 
+(** {1 Pseudo-random number generation} *)
+
+val random_int: ?rng: Random.State.t -> t -> t
+(** [random_int bound] returns a random integer between 0 (inclusive)
+    and [bound] (exclusive).  [bound] must be greater than 0.
+
+    The source of randomness is the {!Random} module from the OCaml
+    standard library.  The optional [rng] argument specifies which
+    random state to use.  If omitted, the default random state for the
+    {!Random} module is used.
+
+    Random numbers produced by this function are not cryptographically
+    strong and must not be used in cryptographic or high-security
+    contexts.  See {!Z.random_int_gen} for an alternative.
+*)
+
+val random_bits: ?rng: Random.State.t -> int -> t
+(** [random_bits nbits] returns a random integer between 0 (inclusive)
+    and [2{^nbits}] (exclusive).  [nbits] must be nonnegative.
+    This is a more efficient special case of {!Z.random_int} when the
+    bound is a power of two.
+
+    The source of randomness and the [rng] optional argument are as
+    described in {!Z.random_int}.
+
+    Random numbers produced by this function are not cryptographically
+    strong and must not be used in cryptographic or high-security
+    contexts.  See {!Z.random_bits_gen} for an alternative.
+*)
+
+val random_int_gen: fill: (bytes -> int -> int -> unit) -> t -> t
+(** [random_int_gen ~fill bound] returns a random integer between 0 (inclusive)
+    and [bound] (exclusive).  [bound] must be greater than 0.
+
+    The [fill] parameter is the source of randomness.  It is called
+    as [fill buf pos len], and is responsible for drawing [len] random
+    bytes and writing them to offsets [pos] to [pos + len - 1] of
+    the byte array [buf].
+
+    Example of use where [/dev/random] provides the random bytes:
+<<
+    In_channel.with_open_bin "/dev/random"
+      (fun ic -> Z.random_int_gen ~fill:(really_input ic) bound)
+>>
+    Example of use where the Cryptokit library provides the random bytes:
+<<
+    Z.random_int_gen ~fill:Cryptokit.Random.secure_rng#bytes bound
+>>
+*)
+
+val random_bits_gen: fill: (bytes -> int -> int -> unit) -> int -> t
+(** [random_bits_gen ~fill nbits] returns a random integer between 0 (inclusive)
+    and [2{^nbits}] (exclusive).  [nbits] must be nonnegative.
+    This is a more efficient special case of {!Z.random_int_gen} when the
+    bound is a power of two.  The [fill] parameter is as described in
+    {!Z.random_int_gen}.
+*)
 
 (** {1 Prefix and infix operators} *)
 


### PR DESCRIPTION
This PR adds functions to generate pseudo-random integers:
- `Z.random_int N` returns an integer between 0 (included) and `N` (excluded)
- `Z.random_bits n` returns an integer that fits in `n` bits, i.e. between 0 (included) and 2^`n` (excluded).

The source of randomness is the Random standard library module, which is not cryptographically secure.  For more demanding applications, lower-level functions `Z.random_int_gen` and `Z.random_bits_gen` are provided, parameterized by a user-provided  function that draws random bytes into a byte array.  The documentation explains how these lower-level functions can be used to produce cryptographically-strong random integers.

Addresses: #99 
