### PR TITLE
Update project.mak

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -151,7 +151,7 @@ clean:
 	make -C tests clean
 
 depend: $(AUTOGEN)
-	$(OCAMLDEP) -native $(OCAMLINC) $(MLSRC) $(MLISRC) > depend
+	$(OCAMLDEP) $(OCAMLINC) $(MLSRC) $(MLISRC) > depend
 
 include depend
 


### PR DESCRIPTION
I suppose that -native is not good for ocamldep. 
depend will not output dependency for bytecode.

See log at https://881129.bugs.gentoo.org/attachment.cgi?id=832035