### PR TITLE
More CI jobs (and add a windows job)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-lastest
+        ocaml-compiler:
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.ignorecase false
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
+          opam-depext: true
+          opam-depext-flags: --with-test
+
+      - name: configure tree
+        run: opam exec -- ./configure
+
+      - name: Build
+        run: opam exec -- make
+
+      - name: Run the testsuite
+        run: opam exec -- make -C tests test
+
+      - run: opam install . --with-test
+
+      - run: opam exec -- git diff --exit-code
+        if: ${{ !matrix.skip-test }}

--- a/tests/pi.ml
+++ b/tests/pi.ml
@@ -61,5 +61,6 @@ let usage () =
 
 let _ =
   let args = Sys.argv in
+  set_binary_mode_out stdout true;
   if Array.length args <> 2 then usage () else
   digits (int_of_string Sys.argv.(1))

--- a/tests/zq.ml
+++ b/tests/zq.ml
@@ -846,5 +846,6 @@ let test_Q () =
 
 (* main *)
 
+let () = set_binary_mode_out stdout true
 let _ = test_Z()
 let _ = test_Q()


### PR DESCRIPTION
In addition to the existing CI, this PR adds 3 more CI jobs using the ocaml-setup github action.

- It gives more freedom regarding what version of ocaml we're testing against
- It enables windows in the CI
- It tests `opam install` as well 

The down side is that it's slower than the existing jobs as it has to recompile the ocaml compiler everytime (modulo caches).
I kept the existing jobs as it gives faster feedback. 

The second commit is necessary to have test pass on windows

fix #98 
