### PR TITLE
more precise bounds for of_float conversion to small ints

### DIFF
--- a/caml_z.c
+++ b/caml_z.c
@@ -160,12 +160,10 @@ extern "C" {
 #endif
 #define Z_FITS_INT(v)  ((v) >= Z_MIN_INT && (v) <= Z_MAX_INT)
 
-/* Z_MAX_INT may not be representable exactly as a double => we use a
-   lower approximation to be safe
- */
+/* greatest/smallest double that can fit in an int */
 #ifdef ARCH_SIXTYFOUR
-#define Z_MAX_INT_FL    0x3ffffffffffff000
-#define Z_MIN_INT_FL    (-Z_MAX_INT_FL)
+#define Z_MAX_INT_FL    0x3ffffffffffffe00
+#define Z_MIN_INT_FL    (-0x4000000000000000)
 #else
 #define Z_MAX_INT_FL    Z_MAX_INT
 #define Z_MIN_INT_FL    Z_MIN_INT


### PR DESCRIPTION
This patch changes the bounds used in `of_float` to decide whether the double can fit into an OCaml 64-bit int.

The previous bounds were conservative: some doubles that could fit in a 64-bit OCaml int were converted to a GMP int instead. It was safe as `ml_z_reduce` converted it back to a OCaml int. But it was wasteful.
The new bounds should be tight and correspond exactly the the smallest/greatest double that can fit in a 64-bit OCaml int.