### PR TITLE
Install Zarith_version.cmx

### DIFF
--- a/project.mak
+++ b/project.mak
@@ -38,7 +38,7 @@ MLISRC = z.mli q.mli big_int_Z.mli
 AUTOGEN = zarith_version.ml
 
 CMIOBJ = $(MLISRC:%.mli=%.cmi)
-CMXOBJ = $(MLISRC:%.mli=%.cmx)
+CMXOBJ = $(MLSRC:%.ml=%.cmx)
 CMIDOC = $(MLISRC:%.mli=%.cmti)
 
 TOBUILD = zarith.cma libzarith.$(LIBSUFFIX) $(CMIOBJ) zarith_top.cma z.mli


### PR DESCRIPTION
With the flambda variants of the compiler, compilation failed for me with 
```
Error (warning 58 [no-cmx-file]): no cmx file was found in path for module Zarith_version, and its interface was not compiled with -opaque
```
(One can silence that warning and everything looks fine but still) Here is a super naive attempt to fix that by simply installing that file...