### PR TITLE
Fix for windows and OCaml 5

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text=auto
 
 configure text eol=lf
+config.guess text eol=lf

--- a/configure
+++ b/configure
@@ -161,7 +161,7 @@ checklib()
     rm -f tmp.ml tmp.out
     echo "" > tmp.ml
     r=1
-    $ocamlc -custom -ccopt "$ccopt $ldflags $cclib" tmp.ml -cclib -l$1 -o tmp.out >/dev/null 2>/dev/null || r=0
+    $ocamlc -custom -ccopt "$ldflags $cclib" tmp.ml -cclib -l$1 -o tmp.out >/dev/null 2>/dev/null || r=0
     if test ! -x tmp.out; then r=0; fi
     rm -f tmp.out tmp.ml tmp.cmi tmp.cmo
     if test $r -eq 0; then echo "not found"; else echo "found"; fi


### PR DESCRIPTION
exported from #133, this patch was suggested by @dra27 for fixing the build with OCaml 5 on windows.

> It'll be working on 4.x because of the CC hack in opam-repository-mingw packages. This works:
``` diff --git a/.gitattributes b/.gitattributes
index 3aa538a..b8cea1e 100644
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text=auto

 configure text eol=lf
+config.guess text eol=lf
\ No newline at end of file
diff --git a/configure b/configure
index 6e87fe9..3acd7a6 100755
--- a/configure
+++ b/configure
@@ -161,7 +161,7 @@ checklib()
     rm -f tmp.ml tmp.out
     echo "" > tmp.ml
     r=1
-    $ocamlc -custom -ccopt "$ccopt $ldflags $cclib" tmp.ml -cclib -l$1 -o tmp.out >/dev/null 2>/dev/null || r=0
+    $ocamlc -custom -ccopt "$ldflags $cclib" tmp.ml -cclib -l$1 -o tmp.out >/dev/null 2>/dev/null || r=0
     if test ! -x tmp.out; then r=0; fi
     rm -f tmp.out tmp.ml tmp.cmi tmp.cmo
     if test $r -eq 0; then echo "not found"; else echo "found"; fi
```
> The rationale is that we've already tested that $ccopt works when testing for the header (in checkinc). For the Windows ports, we can't pass -O3 -Wall -Wextra part because flexlink doesn't recognise those. I think it's OK just to drop $ccopt completely, although possibly that should only be done for Windows. I'm not able to do a PR for this at the moment, though, I'm afraid

I don't really understand the limitation regarding flexlink and what hack were presents in opam-repository-mingw packages.
I'm counting on @dra27 to answer any question regarding this PR.