### PR TITLE
Use standard hash function for `Z.hash` and add `Z.seeded_hash`

### DIFF
--- a/caml_z.c
+++ b/caml_z.c
@@ -3350,11 +3350,6 @@ static intnat ml_z_custom_hash(value v)
   return acc;
 }
 
-CAMLprim value ml_z_hash(value v)
-{
-  return Val_long(ml_z_custom_hash(v));
-}
-
 /* serialized format:
    - 1-byte sign (1 for negative, 0 for positive)
    - 4-byte size in bytes

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,7 +38,7 @@ test:: ofstring.exe
 
 test:: chi2.exe
 	@echo "Testing random number generation..."
-	@./chi2.exe
+	@if ./chi2.exe; then echo "chi2: passed"; else echo "chi2: FAILED"; exit 2; fi
 
 bench:: timings.exe
 	./timings.exe

--- a/z.ml
+++ b/z.ml
@@ -258,7 +258,8 @@ external perfect_power: t -> bool = "ml_z_perfect_power"
 external perfect_square: t -> bool = "ml_z_perfect_square"
 external probab_prime: t -> int -> int = "ml_z_probab_prime"
 external nextprime: t -> t = "ml_z_nextprime"
-external hash: t -> int = "ml_z_hash" [@@noalloc]
+let hash: t -> int = Stdlib.Hashtbl.hash
+let seeded_hash: int -> t -> int = Stdlib.Hashtbl.seeded_hash
 external to_bits: t -> string = "ml_z_to_bits"
 external of_bits: string -> t = "ml_z_of_bits"
 

--- a/z.mli
+++ b/z.mli
@@ -486,12 +486,24 @@ val is_odd: t -> bool
     @since 1.4
 *)
 
-external hash: t -> int = "ml_z_hash" [@@noalloc]
+val hash: t -> int
 (** Hashes a number, producing a small integer.
-    The result is consistent with equality: if [a] = [b], then [hash a] =
-    [hash b].
-    OCaml's generic hash function, [Hashtbl.hash], works correctly with
-    numbers, but {!Z.hash} is slightly faster.
+    The result is consistent with equality:
+    if [a] = [b], then [hash a] = [hash b].
+    The result is the same as produced by OCaml's generic hash function,
+    {!Hashtbl.hash}.
+    Together with type {!Z.t}, the function {!Z.hash} makes it possible
+    to pass module {!Z} as argument to the functor {!Hashtbl.Make}.
+    @before 1.14 a different hash algorithm was used.
+*)
+
+val seeded_hash: int -> t -> int
+(** Like {!Z.hash}, but takes a seed as extra argument for diversification.
+    The result is the same as produced by OCaml's generic seeded hash function,
+    {!Hashtbl.seeded_hash}.
+    Together with type {!Z.t}, the function {!Z.hash} makes it possible
+    to pass module {!Z} as argument to the functor {!Hashtbl.MakeSeeded}.
+    @since 1.14
 *)
 
 (** {1 Elementary number theory} *)
@@ -717,6 +729,8 @@ val random_int: ?rng: Random.State.t -> t -> t
     Random numbers produced by this function are not cryptographically
     strong and must not be used in cryptographic or high-security
     contexts.  See {!Z.random_int_gen} for an alternative.
+
+    @since 1.13
 *)
 
 val random_bits: ?rng: Random.State.t -> int -> t
@@ -731,6 +745,8 @@ val random_bits: ?rng: Random.State.t -> int -> t
     Random numbers produced by this function are not cryptographically
     strong and must not be used in cryptographic or high-security
     contexts.  See {!Z.random_bits_gen} for an alternative.
+
+    @since 1.13
 *)
 
 val random_int_gen: fill: (bytes -> int -> int -> unit) -> t -> t
@@ -751,6 +767,7 @@ val random_int_gen: fill: (bytes -> int -> int -> unit) -> t -> t
 <<
     Z.random_int_gen ~fill:Cryptokit.Random.secure_rng#bytes bound
 >>
+    @since 1.13
 *)
 
 val random_bits_gen: fill: (bytes -> int -> int -> unit) -> int -> t
@@ -759,6 +776,7 @@ val random_bits_gen: fill: (bytes -> int -> int -> unit) -> int -> t
     This is a more efficient special case of {!Z.random_int_gen} when the
     bound is a power of two.  The [fill] parameter is as described in
     {!Z.random_int_gen}.
+    @since 1.13
 *)
 
 (** {1 Prefix and infix operators} *)


### PR DESCRIPTION
For consistency with other integer types in the standard library  (modules Int, Int32, Int64, Nativeint), let's use the standard  hash function (`Hashtbl.hash`) for `Z.hash` instead of our variant.  This is a bit slower but has several benefits:
- 32/64 bit compatibility;
- better mixing of the bits of the result.
    
While we're at it, add a `Z.seeded_hash` function, defined as `Hashtbl.seeded_hash`, so that the `Z` module  can be used as the argument to the `Hashtbl.MakeSeeded` functor.

Also: improve documentation of `Z.hash` and add some more `@since` tags.

Closes #145 as this addresses the needs expressed in #145, while being more consistent with the OCaml stdlib modules.
