### PR TITLE
When ocamlfind is there (and not unplugged), use it to call ocaml tools during compilation

### DIFF
--- a/configure
+++ b/configure
@@ -208,7 +208,7 @@ else
   ccopt="-O3 -Wall -Wextra $CFLAGS"
 fi
 
-case "$("$ocamlc" -config | tr -d '\r' | sed -ne '/^system:/s/.*: //p')" in
+case "$($ocamlc -config | tr -d '\r' | sed -ne '/^system:/s/.*: //p')" in
   win32|win64)
     # MSVC
     objsuffix='obj'
@@ -254,7 +254,7 @@ fi
 # directories
 
 if test "$ocamllibdir" = "auto"
-then ocamllibdir="$(ocamlc -where | tr -d '\r')"
+then ocamllibdir="$($ocamlc -where | tr -d '\r')"
 fi
 
 if test ! -f "$ocamllibdir/caml/mlvalues.h"
@@ -293,7 +293,7 @@ fi
 # detect OCaml's word-size
 
 echo "print_int (Sys.word_size);;" > tmp.ml
-wordsize="$(ocaml tmp.ml)"
+wordsize="$($ocaml tmp.ml)"
 echo "OCaml's word size is $wordsize"
 rm -f tmp.ml
 
@@ -335,7 +335,7 @@ if test "$gmp" != 'OK'; then echo "cannot find GMP nor MPIR"; exit 2; fi
 
 # OCaml version
 
-ocamlver="$(ocamlc -version)"
+ocamlver="$($ocamlc -version)"
 
 # OCaml version 4.07 or later is required
 

--- a/configure
+++ b/configure
@@ -301,11 +301,11 @@ rm -f tmp.ml
 # check GMP, MPIR
 
 if test "$gmp" = 'gmp' || test "$gmp" = 'auto'; then
-    if pkg-config gmp 2>/dev/null; then
+    if ${prefixnonocaml}pkg-config gmp 2>/dev/null; then
         echo 'package gmp: found'
         gmp='OK'
-        cclib="$cclib $(pkg-config --libs gmp)"
-        ccinc="$ccinc $(pkg-config --cflags gmp)"
+        cclib="$cclib $(${prefixnonocaml}pkg-config --libs gmp)"
+        ccinc="$ccinc $(${prefixnonocaml}pkg-config --cflags gmp)"
         ccdef="-DHAS_GMP $ccdef"
     else
         checkinc gmp.h

--- a/configure
+++ b/configure
@@ -190,15 +190,40 @@ checkcmxalib()
     return $r    
 }
 
-
-# check required programs
+# check required program
 
 searchbinreq $ocaml
-searchbinreq $ocamlc
-searchbinreq $ocamldep
-searchbinreq $ocamlmklib
-if searchbin $ocamldoc; then
-  ocamldoc=''
+
+# rely on ocamlfind or not
+
+searchbin ocamlfind
+if test $? -eq 1 && test $ocamlfind != "no"; then
+    # set installation method
+    instmeth='findlib'
+    if test "$installdir" = "auto"
+    then installdir="$(ocamlfind printconf destdir | tr -d '\r')"; fi
+
+    # use wrapper to call compilers
+    ocamlc='ocamlfind ocamlc'
+    ocamlopt='ocamlfind opt'
+    ocamlmklib='ocamlfind ocamlmklib'
+    ocamldep='ocamlfind ocamldep'
+    ocamldoc='ocamlfind ocamldoc'
+else
+    # set installation method
+    searchbin install
+    if test $? -eq 1; then instmeth='install'
+    else echo "no installation method found"; exit 2; fi
+    if test "$installdir" = "auto"; then installdir="$ocamllibdir"; fi
+
+    # check required tools
+    searchbinreq $ocamlc
+    searchbinreq $ocamldep
+    searchbinreq $ocamlmklib
+fi
+
+if $ocamldoc -version >/dev/null 2>/dev/null; then
+    ocamldoc=''
 fi
 
 if test -n "$CC"; then
@@ -236,8 +261,7 @@ esac
 
 hasocamlopt='no'
 
-searchbin $ocamlopt
-if test $? -eq 1; then hasocamlopt='yes'; fi
+if $ocamlopt -version >/dev/null 2>/dev/null; then hasocamlopt='yes'; fi
 
 
 # check C compiler
@@ -272,21 +296,6 @@ if test $hasocamlopt = yes
 then
     checkcmxalib dynlink.cmxa
     if test $? -eq 1; then hasdynlink='yes'; fi
-fi
-
-
-# installation method
-
-searchbin ocamlfind
-if test $? -eq 1 && test $ocamlfind != "no"; then 
-    instmeth='findlib'
-    if test "$installdir" = "auto"
-    then installdir="$(ocamlfind printconf destdir | tr -d '\r')"; fi
-else
-    searchbin install
-    if test $? -eq 1; then instmeth='install'
-    else echo "no installation method found"; exit 2; fi
-    if test "$installdir" = "auto"; then installdir="$ocamllibdir"; fi
 fi
 
 


### PR DESCRIPTION
It is useful for cross-compilation: With it I can do
```
$ OCAMLFIND_TOOLCHAIN=windows ./configure -prefixnonocaml $(opam var conf-gcc-windows64:prefix)
$ OCAMLFIND_TOOLCHAIN=windows make
```
on my linux machine to get a windows build :)

No difference should be detectable in any other situation...
