### PR TITLE
Adds an introductory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ Source files        | Description
   zarith.opam       | package description for opam
   z_mlgmpidl.ml[i]  | conversion between Zarith and MLGMPIDL
   tests/            | simple regression tests and benchmarks
+  examples/         | an annotated introductory example

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# zarith
+
+This example is for the zarith library
+
+https://opam.ocaml.org/packages/zarith
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe`
+
+# Cleaning up
+
+`dune clean`

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries zarith))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,51 @@
+let integers () =
+  (* Build something bigger than an OCaml int can hold. *)
+  let z = Z.of_int max_int in
+  let bigz = Z.mul z z in
+    print_endline (Z.to_string bigz);
+  (* Go even bigger *)
+  let biggerz = Z.shift_left z 100 in
+    print_endline (Z.to_string biggerz);
+    Printf.printf "This has %i significant bits, of which %i are set\n" (Z.numbits biggerz) (Z.popcount biggerz);
+    Printf.printf "Does it fit in an Int64.t? %b\n" (Z.fits_int64 biggerz);
+    (* Logarithm (as an int, because it is small) *)
+    Printf.printf "Logarithm, base two: %i\n" (Z.log2 biggerz);
+    (* Prime just larger than this (probably) *)
+    Printf.printf "Next prime... %s\n" (Z.to_string (Z.nextprime biggerz));
+    (* There are alternative printers: *)
+    print_endline "Decimal:";
+    print_endline (Z.format "%i" biggerz);
+    print_endline "Octal:";
+    print_endline (Z.format "%o" biggerz);
+    print_endline "Binary:";
+    print_endline (Z.format "%b" biggerz);
+    print_endline "Hexadecimal:";
+    print_endline (Z.format "%0#X" biggerz)
+
+let rationals () =
+  (* 1 / 100 *)
+  let q = Q.make (Z.of_int 1) (Z.of_int 100) in
+  (* Or, more easily 1 / 1000 *)
+  let q2 = Q.of_ints 1 1000 in
+  (* Or, even more easily 1 / 10000 *)
+  let open Q in
+  let q3 = 1 // 10000 in
+  (* Or, from a string *)
+  let q4 = Q.of_string "1/10000" in
+    (* Show parts *)
+    Printf.printf "Parts of q3: %s, %s\n" (Z.to_string q3.num) (Z.to_string q3.den);
+    (* Printing *)
+    Q.print q3;
+    print_newline ();
+    (* Arithmetic *)
+    let q5 = Q.mul q3 q4 in
+      print_endline "Multiplied:";
+      Q.print q5;
+      print_newline ();
+      Printf.printf "As a float: %f\n" (Q.to_float q4)
+
+let () =
+  match Sys.argv with
+  | [|_; "integers"|] -> integers ()
+  | [|_; "rationals"|] -> rationals ()
+  | _ -> Printf.eprintf "zarith example: unknown command line\n"

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name zarith_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
This pull request adds some examples to Zarith. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please do give any comments you have on this programme.

(The above is boilerplate. Special note for this PR: You'll notice the example uses Dune. If you decide you want to include this example, we can look at re-writing it using the Makefile structure used elsewhere in Zarith. But I have not invested the time to understand the makefiles yet.)