### PR TITLE
Honor OCAML* environment variables in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+- Honor the `OCAML`, `OCAMLC`, `OCAMLOPT`, `OCAMLMKLIB`, `OCAMLDEP` and `OCAMLDOC` environment variables in configure, so a cross build can supply its own toolchain.
 - #167: Add `Z.to_bytes` and `Z.of_bytes` to convert between integers and byte sequences, with control of byte size and endianness.
 - Make unmarshaling of big integers more resistant to corrupted serialized data, on OCaml 5.4.1 and later.
 - Drop support for OCaml 4.07.  OPAM only supports OCaml >= 4.08 now, and probably >= 4.11 soon.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 - Honor the `OCAML`, `OCAMLC`, `OCAMLOPT`, `OCAMLMKLIB`, `OCAMLDEP` and `OCAMLDOC` environment variables in configure, so a cross build can supply its own toolchain.
+- Do not build `zarith.cmxs` when the compiler reports no shared-library support (e.g. a freestanding/static cross target), gating on `ocamlopt -config` rather than the mere presence of `dynlink.cmxa`.
 - #167: Add `Z.to_bytes` and `Z.of_bytes` to convert between integers and byte sequences, with control of byte size and endianness.
 - Make unmarshaling of big integers more resistant to corrupted serialized data, on OCaml 5.4.1 and later.
 - Drop support for OCaml 4.07.  OPAM only supports OCaml >= 4.08 now, and probably >= 4.11 soon.

--- a/configure
+++ b/configure
@@ -21,12 +21,12 @@ ocamllibdir='auto'
 gmp='auto'
 perf='no'
 
-ocaml='ocaml'
-ocamlc='ocamlc'
-ocamlopt='ocamlopt'
-ocamlmklib='ocamlmklib'
-ocamldep='ocamldep'
-ocamldoc='ocamldoc'
+ocaml="${OCAML:-ocaml}"
+ocamlc="${OCAMLC:-ocamlc}"
+ocamlopt="${OCAMLOPT:-ocamlopt}"
+ocamlmklib="${OCAMLMKLIB:-ocamlmklib}"
+ocamldep="${OCAMLDEP:-ocamldep}"
+ocamldoc="${OCAMLDOC:-ocamldoc}"
 ccinc="$CPPFLAGS"
 ldflags="$LDFLAGS"
 cclib=''
@@ -254,7 +254,7 @@ fi
 # directories
 
 if test "$ocamllibdir" = "auto"
-then ocamllibdir="$(ocamlc -where | tr -d '\r')"
+then ocamllibdir="$($ocamlc -where | tr -d '\r')"
 fi
 
 if test ! -f "$ocamllibdir/caml/mlvalues.h"
@@ -335,7 +335,7 @@ if test "$gmp" != 'OK'; then echo "cannot find GMP nor MPIR"; exit 2; fi
 
 # OCaml version
 
-ocamlver="$(ocamlc -version)"
+ocamlver="$($ocamlc -version)"
 
 # OCaml version 4.08 or later is required
 

--- a/configure
+++ b/configure
@@ -268,7 +268,11 @@ if test $? -eq 0; then echo "cannot include caml/mlvalues.h"; exit 2; fi
 
 hasdynlink='no'
 
-if test $hasocamlopt = yes
+# A static/freestanding cross target has no shared libraries but still ships
+# dynlink.cmxa, so gate on the compiler's report instead.
+if test $hasocamlopt = yes \
+    && $ocamlopt -config 2>/dev/null \
+       | grep -q '^supports_shared_libraries: *true'
 then
     checkcmxalib dynlink.cmxa
     if test $? -eq 1; then hasdynlink='yes'; fi


### PR DESCRIPTION
`configure` hardcodes the OCaml tools to bare names (`ocamlc`, `ocamlopt`, ...), so it can't be pointed at a cross toolchain: cross-compiling builds `caml_z.c` against the host compiler and headers, not the target's.

This PR makes each tool honor an environment variable (`OCAML`, `OCAMLC`, `OCAMLOPT`, `OCAMLMKLIB`, `OCAMLDEP`, `OCAMLDOC`), falling back to the bare name when unset so native builds are unchanged. Setting `OCAMLC="ocamlfind -toolchain <target> ocamlc"` (etc.) then builds for that target.

Came up cross-building MirageOS unikernels on macOS:
- Solo5/solo5#641 builds the aarch64 cross toolchain
- mirage/ocaml-solo5#171 builds the aarch64 cross-compiler
- mirage/ocaml-gmp#29 installs a relocatable `gmp.pc`
- mirage/ocaml-gmp#30 archives `libgmp.a` with the cross `ar`/`ranlib`


